### PR TITLE
Fix gcs-cli and pubsub-cli script definitions

### DIFF
--- a/obs_common/gcs_cli.py
+++ b/obs_common/gcs_cli.py
@@ -161,10 +161,5 @@ def upload(source, destination):
         click.echo(f"Uploaded gs://{bucket_name}/{key}")
 
 
-def main(argv=None):
-    argv = argv or []
-    gcs_group(argv)
-
-
 if __name__ == "__main__":
     gcs_group()

--- a/obs_common/pubsub_cli.py
+++ b/obs_common/pubsub_cli.py
@@ -168,10 +168,5 @@ def pull(ctx, project_id, subscription_name, ack, max_messages):
         subscriber.acknowledge(subscription=subscription_path, ack_ids=ack_ids)
 
 
-def main(argv=None):
-    argv = argv or []
-    pubsub_group(argv)
-
-
 if __name__ == "__main__":
     pubsub_group()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ dynamic = ["version"]
 [project.scripts]
 license-check = "obs_common.license_check:main"
 service-status = "obs_common.service_status:main"
-gcs-cli = "obs_common.gcs_cli:main"
-pubsub-cli = "obs_common.pubsub_cli:main"
+gcs-cli = "obs_common.gcs_cli:gcs_group"
+pubsub-cli = "obs_common.pubsub_cli:pubsub_group"
 sentry-wrap = "obs_common.sentry_wrap:cli_main"
 
 [build-system]


### PR DESCRIPTION
without this the scripts installed (`gcs-cli` and `pubsub-cli`) cannot detect any arguments passed