### PR TITLE
Fix dependabot updates for docker/images/*

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,9 @@ updates:
     rebase-strategy: "disabled"
 
   - package-ecosystem: "docker"
-    directory: "/docker"
+    directories:
+      - "/docker"
+      - "/docker/images/*"
     schedule:
       interval: "monthly"
 


### PR DESCRIPTION
switches from directory to directories, as documented here: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directories

directories explicitly supports wildcards