### PR TITLE
Improve error message from gcs-cli without STORAGE_EMULATOR_HOST

### DIFF
--- a/obs_common/gcs_cli.py
+++ b/obs_common/gcs_cli.py
@@ -8,6 +8,7 @@
 
 # Usage: ./bin/gcs_cli.py CMD
 
+import os
 from pathlib import Path, PurePosixPath
 
 import click
@@ -18,6 +19,10 @@ from google.cloud.exceptions import Conflict, NotFound
 
 
 def get_client():
+    if "STORAGE_EMULATOR_HOST" not in os.environ:
+        raise click.ClickException(
+            "STORAGE_EMULATOR_HOST must point to gcs emulator, but it's not set."
+        )
     return storage.Client(credentials=AnonymousCredentials())
 
 


### PR DESCRIPTION
right now it throws `google.auth.exceptions.InvalidOperation: Anonymous credentials cannot be refreshed.`, which isn't very helpful if you don't already know what's wrong.

This doesn't touch pubsub-cli which will access real pubsub if no emulator is set

fixes #29 