### PR TITLE
Migrate service-status from argparse to click

### DIFF
--- a/obs_common/service_status.py
+++ b/obs_common/service_status.py
@@ -123,8 +123,7 @@ def main(main_branch, hosts):
         data = tomllib.loads(pyproject_toml.read_text())
         config_data = data.get("tool", {}).get("service-status", {})
 
-    if main_branch is None:
-        main_branch = config_data.get("main_branch", "main")
+    main_branch = main_branch or config_data.get("main_branch", "main")
 
     if not hosts:
         if "hosts" in config_data:

--- a/tests/test_service_status.py
+++ b/tests/test_service_status.py
@@ -1,0 +1,14 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from click.testing import CliRunner
+
+from obs_common import service_status
+
+
+def test_it_runs():
+    """Test whether the module loads and spits out help."""
+    runner = CliRunner()
+    result = runner.invoke(service_status.main, ["--help"])
+    assert result.exit_code == 0


### PR DESCRIPTION
fixes #39

manually tested by running:
```sh
make shell
service-status # expect error message about no hosts
service-status --host=stage=https://crash-stats.allizom.org
```

I didn't add CI tests because CI shouldn't depend on github being up, but also mocking out github and an http server seemed excessive. If adding a test like that is desirable lmk.