### PR TITLE
Use kebab case for subcommand names

### DIFF
--- a/obs_common/gcs_cli.py
+++ b/obs_common/gcs_cli.py
@@ -76,7 +76,7 @@ def delete_bucket(bucket_name):
     click.echo(f"GCS bucket {bucket_name!r} deleted.")
 
 
-@gcs_group.command("list_buckets")
+@gcs_group.command()
 @click.option("--details/--no-details", default=True, type=bool, help="With details")
 def list_buckets(details):
     """List GCS buckets"""
@@ -92,7 +92,7 @@ def list_buckets(details):
             click.echo(f"{bucket.name}")
 
 
-@gcs_group.command("list_objects")
+@gcs_group.command()
 @click.option("--details/--no-details", default=True, type=bool, help="With details")
 @click.argument("bucket_name")
 def list_objects(bucket_name, details):
@@ -118,7 +118,7 @@ def list_objects(bucket_name, details):
         click.echo("No objects in bucket.")
 
 
-@gcs_group.command("upload")
+@gcs_group.command()
 @click.argument("source")
 @click.argument("destination")
 def upload(source, destination):

--- a/obs_common/pubsub_cli.py
+++ b/obs_common/pubsub_cli.py
@@ -22,7 +22,7 @@ def pubsub_group():
     """Local dev environment Pub/Sub emulator manipulation script."""
 
 
-@pubsub_group.command("list_topics")
+@pubsub_group.command()
 @click.argument("project_id")
 @click.pass_context
 def list_topics(ctx, project_id):
@@ -34,7 +34,7 @@ def list_topics(ctx, project_id):
         click.echo(topic.name)
 
 
-@pubsub_group.command("list_subscriptions")
+@pubsub_group.command()
 @click.argument("project_id")
 @click.argument("topic_name")
 @click.pass_context
@@ -48,7 +48,7 @@ def list_subscriptions(ctx, project_id, topic_name):
         click.echo(subscription)
 
 
-@pubsub_group.command("create_topic")
+@pubsub_group.command()
 @click.argument("project_id")
 @click.argument("topic_name")
 @click.pass_context
@@ -64,7 +64,7 @@ def create_topic(ctx, project_id, topic_name):
         click.echo("Topic already created.")
 
 
-@pubsub_group.command("create_subscription")
+@pubsub_group.command()
 @click.argument("project_id")
 @click.argument("topic_name")
 @click.argument("subscription_name")
@@ -83,7 +83,7 @@ def create_subscription(ctx, project_id, topic_name, subscription_name):
         click.echo("Subscription already created.")
 
 
-@pubsub_group.command("delete_topic")
+@pubsub_group.command()
 @click.argument("project_id")
 @click.argument("topic_name")
 @click.pass_context
@@ -106,7 +106,7 @@ def delete_topic(ctx, project_id, topic_name):
         click.echo(f"Topic {topic_name} does not exist.")
 
 
-@pubsub_group.command("publish")
+@pubsub_group.command()
 @click.argument("project_id")
 @click.argument("topic_name")
 @click.argument("crashids", nargs=-1)
@@ -138,7 +138,7 @@ def publish(ctx, project_id, topic_name, crashids):
         click.echo(future.result())
 
 
-@pubsub_group.command("pull")
+@pubsub_group.command()
 @click.argument("project_id")
 @click.argument("subscription_name")
 @click.option("--ack/--no-ack", is_flag=True, default=False)


### PR DESCRIPTION
script names use kebab case, sentry-wrap uses kebab case for subcommands, in socorro pubsub_cli.py uses kebab case, and kebab case is the default for click. 

in obs-common gcs-cli and pubsub-cli are currently using snake case for subcommands, and I think we should standardize on kebab-case.