### PR TITLE
Work around dependabot not updating docker-compose

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,13 +71,31 @@ jobs:
         run: echo RELEASE_TAG="$(venv/bin/python -c 'import obs_common.release; print(obs_common.release.generate_tag())')" >> "$GITHUB_ENV"
       - name: Overrride dynamic version
         run: sed 's/dynamic = \["version"]/# dynamic = ["version"]\nversion = "'"$RELEASE_TAG"'"/' -i pyproject.toml
-      - name: Build wheel
+      - name: Build python wheel
         run: venv/bin/python -m build
+      - name: Build docker images for publishing
+        run: docker compose build fakesentry gcs-emulator
       - uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: artifact-writer@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com
-      - name: Publish package
+      - name: Push fakesentry Docker image to GAR
+        uses: mozilla-it/deploy-actions/docker-push@v3.12.0
+        with:
+          local_image: local/obs-common-fakesentry:latest
+          image_repo_path: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/cavendish-prod/fakesentry
+          image_tag: ${{ env.RELEASE_TAG }}
+          workload_identity_pool_project_number: ${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+      - name: Push gcs-emulator Docker image to GAR
+        uses: mozilla-it/deploy-actions/docker-push@v3.12.0
+        with:
+          local_image: local/obs-common-gcs-emulator:latest
+          image_repo_path: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/cavendish-prod/gcs-emulator
+          image_tag: ${{ env.RELEASE_TAG }}
+          workload_identity_pool_project_number: ${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+      - name: Publish python package
         run:
           venv/bin/twine upload --verbose --repository-url https://us-python.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/cavendish-prod-python/ dist/*.whl
       - name: Publish release

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,9 @@ services:
   # https://github.com/fsouza/fake-gcs-server
   # Fake GCP GCS server for local development and testing
   gcs-emulator:
-    image: fsouza/fake-gcs-server:1.49.2
+    build:
+      context: docker/images/gcs-emulator
+    image: local/obs-common-gcs-emulator
     command: -port 8001 -scheme http
     ports:
       - "${EXPOSE_GCS_EMULATOR_PORT:-8001}:8001"
@@ -54,8 +56,9 @@ services:
   # https://cloud.google.com/sdk/docs/downloads-docker
   # official pubsub emulator
   pubsub:
-    # also available as google/cloud-sdk:<version>-emulators
-    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:463.0.0-emulators
+    build:
+      context: docker/images/pubsub-emulator
+    image: local/obs-common-pubsub-emulator
     command:
       - gcloud
       - beta

--- a/docker/images/gcs-emulator/Dockerfile
+++ b/docker/images/gcs-emulator/Dockerfile
@@ -1,0 +1,4 @@
+FROM fsouza/fake-gcs-server:1.50.2@sha256:23996047676fe5312001b828d800670519181c57a5943c2270e7421f3ab3f477
+
+# add curl for use in healthcheck
+RUN apk add --no-cache curl

--- a/docker/images/pubsub-emulator/Dockerfile
+++ b/docker/images/pubsub-emulator/Dockerfile
@@ -1,0 +1,3 @@
+# Define this image outside of docker-compose.yml so that it gets dependabot updates
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:463.0.0-emulators@sha256:4a3ef96d0379a5bf94285e743902a4d7da7f191aac6a542464e096bc72585eaa
+# also available as google/cloud-sdk:<version>-emulators


### PR DESCRIPTION
by putting external images in dockerfiles

and publish fakesentry and gcs-emulator images to GAR