### PR TITLE
Fix docker image path for GAR

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,7 +83,7 @@ jobs:
         uses: mozilla-it/deploy-actions/docker-push@v3.12.0
         with:
           local_image: local/obs-common-fakesentry:latest
-          image_repo_path: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/cavendish-prod/fakesentry
+          image_repo_path: ${{ secrets.GCP_PROJECT_ID }}/cavendish-prod/fakesentry
           image_tag: ${{ env.RELEASE_TAG }}
           workload_identity_pool_project_number: ${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
           project_id: ${{ secrets.GCP_PROJECT_ID }}
@@ -91,7 +91,7 @@ jobs:
         uses: mozilla-it/deploy-actions/docker-push@v3.12.0
         with:
           local_image: local/obs-common-gcs-emulator:latest
-          image_repo_path: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/cavendish-prod/gcs-emulator
+          image_repo_path: ${{ secrets.GCP_PROJECT_ID }}/cavendish-prod/gcs-emulator
           image_tag: ${{ env.RELEASE_TAG }}
           workload_identity_pool_project_number: ${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
           project_id: ${{ secrets.GCP_PROJECT_ID }}


### PR DESCRIPTION
`mozilla-it/deploy-actions/docker-push` adds the `us-docker.pkg.dev/` prefix, so it was redundant here and prevented publishing in https://github.com/mozilla-services/obs-common/actions/runs/11899303361/job/33157702830

I confirmed this works by temporarily modifying the github action to push the docker image for not-main and then quitting before publishing the release to github for this github action run: https://github.com/mozilla-services/obs-common/actions/runs/11899557055/job/33158479534