### PR TITLE
pubsub-cli: strip whitespace when reading crashids from stdin

### DIFF
--- a/obs_common/pubsub_cli.py
+++ b/obs_common/pubsub_cli.py
@@ -122,7 +122,11 @@ def publish(ctx, project_id, topic_name, crashids):
 
     # Pull crash ids from stdin if there are any
     if not crashids and not sys.stdin.isatty():
-        crashids = list(click.get_text_stream("stdin").readlines())
+        crashids = [
+            line.strip()
+            for line in click.get_text_stream("stdin").readlines()
+            if line.strip()  # ignore empty lines
+        ]
 
     if not crashids:
         raise click.BadParameter(


### PR DESCRIPTION
while testing socorro dev docs, I tried `cat crashids.txt | pubsub-cli publish test local-standard-topic` and couldn't figure out why the crashes weren't getting processed. I eventually tracked it down to the published crashids having a trailing newline, which this fixes.