### PR TITLE
Set ack_deadline_timeout for subscriptions (#64)

### DIFF
--- a/obs_common/pubsub_cli.py
+++ b/obs_common/pubsub_cli.py
@@ -77,7 +77,11 @@ def create_subscription(ctx, project_id, topic_name, subscription_name):
     subscriber = pubsub_v1.SubscriberClient()
     subscription_path = subscriber.subscription_path(project_id, subscription_name)
     try:
-        subscriber.create_subscription(name=subscription_path, topic=topic_path)
+        subscriber.create_subscription(
+            name=subscription_path,
+            topic=topic_path,
+            ack_deadline_seconds=600,
+        )
         click.echo(f"Subscription created: {subscription_path}")
     except AlreadyExists:
         click.echo("Subscription already created.")


### PR DESCRIPTION
This re-implements the fix from
https://github.com/mozilla-services/socorro/pull/6689

Before this fix, the ack_deadline_timeout is 10 seconds which isn't long enough for the Socorro processor to process a crash report which causes the crash id to be available in the subscription again which causes the crash report to get reprocessed over and over again.