### PR TITLE
Add host to section line in service-status (#78)

### DIFF
--- a/obs_common/service_status.py
+++ b/obs_common/service_status.py
@@ -143,9 +143,10 @@ def main(main_branch, hosts):
         else:
             env_name, service = parts
 
-        if current_section != env_name:
-            out.section(env_name)
-            current_section = env_name
+        section_key = f"{env_name}: {service}"
+        if current_section != section_key:
+            out.section(section_key)
+            current_section = section_key
 
         service = service.rstrip("/")
         resp = fetch(f"{service}/__version__")


### PR DESCRIPTION
Now the output is like this:

```
stage: https://tecken-stage.symbols.nonprod.webservices.mozgcp.net/
===================================================================

  tecken        version       709cb61b0dcdb61f8d344cae27dd0c68db17a6f3 main
                status        identical


prod: https://symbols.mozilla.org
=================================

  tecken        version       709cb61b0dcdb61f8d344cae27dd0c68db17a6f3 main
                status        identical
```

Fixes #78.