### PR TITLE
add .git to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,4 @@ build
 dist/
 obs_common.egg-info/
 venv/
+.git


### PR DESCRIPTION
`.git` contains auth tokens for github actions, and while we don't publish the obs-common-shell image, we should still proactively remove that footgun