### PR TITLE
CRINGE-24: Fix version detection in local container builds.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -79,7 +79,7 @@ jobs:
             *-*) SUBVERSION=".${VERSION##*-}";;
             *) SUBVERSION="";;
           esac
-          echo SETUPTOOLS_SCM_PRETEND_VERSION="$MAIN_VERSION$SUBVERSION" >> "$GITHUB_ENV"
+          echo SETUPTOOLS_SCM_PRETEND_VERSION_FOR_OBS_COMMON="$MAIN_VERSION$SUBVERSION" >> "$GITHUB_ENV"
       - name: Build python wheel
         run: venv/bin/python -m build
       - name: Build docker images for publishing

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,8 @@ RUN pip install -U 'pip>=20' && \
 
 COPY --chown=app:app . /app
 
-RUN pip install -e . --no-deps
+ARG version=1.0
+RUN SETUPTOOLS_SCM_PRETEND_VERSION_FOR_OBS_COMMON=${version} pip install -e . --no-deps
 
 USER app
 


### PR DESCRIPTION
The changes in #114 appear to have broken local container builds (probably due to the version upgrade for setuptools-scm). This fixes local container builds (and uses the recommended more specific environment variable in CI builds).

https://mozilla-hub.atlassian.net/browse/CRINGE-24