### PR TITLE
CRINGE-65: Upgrade to version 4 of the docker-push action.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,25 +83,23 @@ jobs:
       - name: Build python wheel
         run: venv/bin/python -m build
       - name: Build docker images for publishing
-        run: docker compose build fakesentry gcs-emulator
+        run: |
+          docker compose build fakesentry gcs-emulator
+          GAR_REPO="us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/cavendish-prod"
+          FAKESENTRY_TAG="$GAR_REPO/fakesentry:${{ env.RELEASE_TAG }}"
+          docker tag local/obs-common-fakesentry:latest "$FAKESENTRY_TAG"
+          GCS_EMULATOR_TAG=$GAR_REPO/gcs-emulator:${{ env.RELEASE_TAG }}"
+          docker tag local/obs-common-gcs-emulator:latest "$GCS_EMULATOR_TAG"
+          echo DOCKER_IMAGE_TAGS="$FAKESENTRY_TAG
+          $GCS_EMULATOR_TAG" >> "$GITHUB_ENV"
       - uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: artifact-writer@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com
-      - name: Push fakesentry Docker image to GAR
+      - name: Push fakesentry and gcs-emulator Docker images to GAR
         uses: mozilla-it/deploy-actions/docker-push@v4.0.6
         with:
-          local_image: local/obs-common-fakesentry:latest
-          image_repo_path: ${{ secrets.GCP_PROJECT_ID }}/cavendish-prod/fakesentry
-          image_tag: ${{ env.RELEASE_TAG }}
-          workload_identity_pool_project_number: ${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-      - name: Push gcs-emulator Docker image to GAR
-        uses: mozilla-it/deploy-actions/docker-push@v4.0.6
-        with:
-          local_image: local/obs-common-gcs-emulator:latest
-          image_repo_path: ${{ secrets.GCP_PROJECT_ID }}/cavendish-prod/gcs-emulator
-          image_tag: ${{ env.RELEASE_TAG }}
+          image_tags: ${{ env.DOCKER_IMAGE_TAGS }}
           workload_identity_pool_project_number: ${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
           project_id: ${{ secrets.GCP_PROJECT_ID }}
       - name: Publish python package


### PR DESCRIPTION
When I upgraded the crash ingestion services to the new version of the docker-push action a couple of weeks ago, I missed this repo.

https://mozilla-hub.atlassian.net/browse/CRINGE-65