### PR TITLE
CRINGE-65: Use correct GitHub Actions multiline env variable syntax.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,7 +83,6 @@ jobs:
       - name: Build python wheel
         run: venv/bin/python -m build
       - name: Build docker images for publishing
-        shell: bash
         run: |
           docker compose build fakesentry gcs-emulator
           GAR_REPO="us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/cavendish-prod"
@@ -91,7 +90,10 @@ jobs:
           docker tag local/obs-common-fakesentry:latest "$FAKESENTRY_TAG"
           GCS_EMULATOR_TAG="$GAR_REPO/gcs-emulator:${{ env.RELEASE_TAG }}"
           docker tag local/obs-common-gcs-emulator:latest "$GCS_EMULATOR_TAG"
-          echo -e DOCKER_IMAGE_TAGS="$FAKESENTRY_TAG\n$GCS_EMULATOR_TAG" >> "$GITHUB_ENV"
+          echo "DOCKER_IMAGE_TAGS<<EOF
+          $FAKESENTRY_TAG
+          $GCS_EMULATOR_TAG
+          EOF" >> "$GITHUB_ENV"
       - uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}


### PR DESCRIPTION
It turns out [multiline environment variables in GitHub Actions need to use a special syntax](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#multiline-strings).

https://mozilla-hub.atlassian.net/browse/CRINGE-65