### PR TITLE
OBS-72: Prevent GitHub Actions release jobs from running concurrently.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,6 +55,8 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' }}
     needs: test
     runs-on: ubuntu-latest
+    concurrency:
+      group: release
     steps:
       - uses: actions/checkout@v5
       - name: Fetch tags


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/CRINGE-72