### PR TITLE
Upgrade click and pip-tools to latest versions.

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,8 +1,8 @@
-click==8.2.1
+click==8.3.0
 google-cloud-pubsub==2.31.1
 google-cloud-storage==3.4.0
 keyrings.google-artifactregistry-auth
-pip-tools==7.5.0
+pip-tools==7.5.1
 pytest==8.4.2
 requests==2.32.5
 ruff==0.13.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -185,9 +185,9 @@ charset-normalizer==3.4.1 \
     --hash=sha256:fd4ec41f914fa74ad1b8304bbc634b3de73d2a0889bd32076342a573e0779e00 \
     --hash=sha256:ffc9202a29ab3920fa812879e95a9e78b2465fd10be7fcbd042899695d75e616
     # via requests
-click==8.2.1 \
-    --hash=sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202 \
-    --hash=sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b
+click==8.3.0 \
+    --hash=sha256:9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc \
+    --hash=sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4
     # via
     #   -r requirements.in
     #   pip-tools
@@ -484,9 +484,9 @@ packaging==24.2 \
     #   build
     #   pytest
     #   twine
-pip-tools==7.5.0 \
-    --hash=sha256:30639f50961bb09f49d22f4389e8d7d990709677c094ce1114186b1f2e9b5821 \
-    --hash=sha256:69758e4e5a65f160e315d74db46246fdbb30d549f1ed0c4236d057122c9b0f18
+pip-tools==7.5.1 \
+    --hash=sha256:a051a94794ba52df9acad2d7c9b0b09ae001617db458a543f8287fea7b89c2cf \
+    --hash=sha256:f5ff803823529edc0e6e40c86b1aa7da7266fb1078093c8beea4e5b77877036a
     # via -r requirements.in
 pluggy==1.5.0 \
     --hash=sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1 \


### PR DESCRIPTION
I split out the click upgrade from https://github.com/mozilla-services/obs-common/pull/167 because it caused a CI failure. It turned out that the CI failure was [caused by a pip-tools bug](https://github.com/jazzband/pip-tools/issues/2238) that got triggered by the click upgrade, since pip-tools depend on click as well. A fixed version of pip-tools got released in the meantime, so we can now upgrade click when upgrading pip-tools at the same time.