### PR TITLE
bug-2037435: Add notification command to gcs-cli.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ gcs-cli --help
 pubsub-cli --help
 ```
 
+To test these commands manually during development, you can set the `PUBSUB_EMULATOR_HOST` and `STORAGE_EMULATOR_HOST` environment variables, start the emulators and run the commands using `uv`
+```
+export PUBSUB_EMULATOR_HOST="localhost:${EXPOSE_PUBSUB_EMULATOR_PORT:-5010}"
+export STORAGE_EMULATOR_HOST="http://localhost:${EXPOSE_GCS_EMULATOR_PORT:-8001}"
+just up
+uv run gcs-cli
+uv run pubsub-cli
+```
 ## waitfor
 
 Performs GET requests against given URL until HTTP 200 or exceeds wait timeout.

--- a/docker/images/gcs-emulator/Dockerfile
+++ b/docker/images/gcs-emulator/Dockerfile
@@ -1,4 +1,4 @@
-FROM fsouza/fake-gcs-server:1.54.0@sha256:3730da0e31f7e5186a90ec4899dc2c336104e7599df400411392ef17e684c31f
+FROM fsouza/fake-gcs-server:1.55.1@sha256:91afded49de804aa61b5f3eb6c7cd65205acf9e5c5e047cf0ba7d9507af806c8
 
 # add curl for use in healthcheck
 RUN apk add --no-cache curl

--- a/obs_common/gcs_cli.py
+++ b/obs_common/gcs_cli.py
@@ -49,6 +49,28 @@ def create_bucket(bucket_name):
         click.echo(f"GCS bucket {bucket_name!r} created.")
 
 
+@gcs_group.command()
+@click.argument("bucket_name")
+@click.argument("topic_project")
+@click.argument("topic_name")
+@click.argument("event_types", nargs=-1, default=("OBJECT_FINALIZE",))
+def notification(bucket_name, topic_project, topic_name, event_types):
+    """Creates a Pub/Sub notification configuration for a bucket."""
+    client = get_client()
+    try:
+        bucket = client.get_bucket(bucket_name)
+    except NotFound:
+        click.echo(f"GCS bucket {bucket_name!r} does not exist.")
+        return
+    bucket.notification(
+        topic_project=topic_project,
+        topic_name=topic_name,
+        event_types=list(event_types),
+        payload_format="JSON_API_V1",
+    ).create()
+    click.echo(f"GCS notification for bucket {bucket_name!r} created.")
+
+
 @gcs_group.command("delete")
 @click.argument("bucket_name")
 def delete_bucket(bucket_name):

--- a/obs_common/gcs_cli.py
+++ b/obs_common/gcs_cli.py
@@ -55,7 +55,7 @@ def create_bucket(bucket_name):
 @click.argument("topic_name")
 @click.argument("event_types", nargs=-1, default=("OBJECT_FINALIZE",))
 def notification(bucket_name, topic_project, topic_name, event_types):
-    """Creates a Pub/Sub notification configuration for a bucket."""
+    """Create a pub/sub notification configuration for a bucket."""
     client = get_client()
     try:
         bucket = client.get_bucket(bucket_name)
@@ -69,6 +69,26 @@ def notification(bucket_name, topic_project, topic_name, event_types):
         payload_format="JSON_API_V1",
     ).create()
     click.echo(f"GCS notification for bucket {bucket_name!r} created.")
+
+
+@gcs_group.command()
+@click.argument("bucket_name")
+def list_notifications(bucket_name):
+    """List pub/sub notification configurations for the given bucket."""
+    client = get_client()
+    try:
+        bucket = client.get_bucket(bucket_name)
+    except NotFound:
+        click.echo(f"GCS bucket {bucket_name!r} does not exist.")
+        return
+    configs = list(bucket.list_notifications())
+    if configs:
+        for config in configs:
+            click.echo(
+                f"{config.topic_project}\t{config.topic_name}\t{config.event_types}"
+            )
+    else:
+        click.echo(f"No notification configurations for bucket {bucket_name}.")
 
 
 @gcs_group.command("delete")

--- a/tests/test_gcs_cli.py
+++ b/tests/test_gcs_cli.py
@@ -73,6 +73,11 @@ class GcsHelper:
         blobs = list(self.client.list_blobs(bucket_or_name=bucket_name))
         return [blob.name for blob in blobs]
 
+    def list_notifications(self, bucket_name):
+        """Return the list of notification configurations for the given bucket."""
+        bucket = self.create_bucket(bucket_name)
+        return bucket.list_notifications()
+
 
 @pytest.fixture
 def gcs_helper():
@@ -85,6 +90,21 @@ def test_it_runs():
     runner = CliRunner()
     result = runner.invoke(gcs_group, ["--help"])
     assert result.exit_code == 0
+
+
+@REQUIRE_EMULATOR
+def test_create_notification(gcs_helper):
+    """Test creating a notification configuration type."""
+    bucket = gcs_helper.create_bucket("test").name
+    result = CliRunner().invoke(
+        gcs_group, ["notification", bucket, "test-project", "test-topic"]
+    )
+    assert result.exit_code == 0
+    [notification_config] = gcs_helper.list_notifications(bucket)
+    assert notification_config.topic_project == "test-project"
+    assert notification_config.topic_name == "test-topic"
+    assert notification_config.event_types == ["OBJECT_FINALIZE"]
+    assert notification_config.payload_format == "JSON_API_V1"
 
 
 @REQUIRE_EMULATOR

--- a/tests/test_gcs_cli.py
+++ b/tests/test_gcs_cli.py
@@ -108,6 +108,32 @@ def test_create_notification(gcs_helper):
 
 
 @REQUIRE_EMULATOR
+def test_list_notifications(gcs_helper):
+    """Test listing notification configurations."""
+    bucket = gcs_helper.create_bucket("test").name
+
+    result = CliRunner().invoke(
+        gcs_group,
+        ["list-notifications", bucket],
+    )
+    assert result.exit_code == 0, result.output
+    assert result.output == (f"No notification configurations for bucket {bucket}.\n")
+
+    result = CliRunner().invoke(
+        gcs_group,
+        ["notification", bucket, "test-project", "test-topic"],
+    )
+    assert result.exit_code == 0
+
+    result = CliRunner().invoke(
+        gcs_group,
+        ["list-notifications", bucket],
+    )
+    assert result.exit_code == 0, result.output
+    assert result.output == ("test-project\ttest-topic\t['OBJECT_FINALIZE']\n")
+
+
+@REQUIRE_EMULATOR
 def test_upload_file_to_root(gcs_helper, tmp_path):
     """Test uploading one file to a bucket root."""
     bucket = gcs_helper.create_bucket("test").name


### PR DESCRIPTION
For the new Tecken upload API we need Cloud Storage Pub/Sub notifications. We use gcs-cli to set up Cloud Storage buckets in the emulator, so we need to add the ability to configure Pub/Sub notifications to the tool.

The GCS emulator only recently gained the ability to configure Pub/Sub notifications, so  we also need to upgrade the emulator to the latest version to make the tests pass.